### PR TITLE
action should use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ inputs:
 # Outputs?
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
node 16 eol

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/