### PR TITLE
fix: reveal the entire error response when logging

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 import * as httpc from '@actions/http-client';
 import * as core from '@actions/core';
+import * as util from 'util';
 
 export default class LDClient {
   constructor(accessToken, baseUri) {
@@ -43,7 +44,7 @@ export default class LDClient {
         core.setFailed('Failed');
       }
     } catch (e) {
-      console.error(e);
+      console.error(util.inspect(e, { showHidden: false, depth: null, colors: true }));
       core.setFailed(e);
     }
 


### PR DESCRIPTION
The error message logged has its details hidden in the nested error object. This PR attempts to fix this by logging with the node js `inspect` util

![IMG_6898](https://github.com/user-attachments/assets/57fcd9d9-afda-4e1b-9fc8-02e1e5085414)
